### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,8 @@ on:
 
 jobs:
   build:
-
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/Short-io/qreator/security/code-scanning/1](https://github.com/Short-io/qreator/security/code-scanning/1)

To fix the problem, we should add a `permissions` block to the `build` job in `.github/workflows/test.yml`, specifying the least privilege required. For a typical build/test job, this is usually `contents: read`, which allows the job to read repository contents but not write to them. This change should be made directly under the `build:` job definition, before the `runs-on:` key (or immediately after, as per YAML conventions). No additional imports or definitions are needed; this is a configuration change in the workflow YAML file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
