### PR TITLE
Fix empty finder patterns from non-finite borderRadius

### DIFF
--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -1,8 +1,7 @@
 import { PDFWriter } from "./pdf-writer/index.js";
 import { QR } from "./qr-base.js";
 import { ImageOptions, Matrix, ResolvedImageOptions } from "./typing/types.js";
-import { computeLabelLayout, getOptions, getDotsSVGPath, getFindersSVGPath, getFinderOuterSVGPath, getFinderInnerSVGPath, LabelLayout } from "./utils.js";
-import colorString from "color-string";
+import { computeLabelLayout, getOptions, getDotsSVGPath, getFindersSVGPath, getFinderOuterSVGPath, getFinderInnerSVGPath, parseColor, LabelLayout } from "./utils.js";
 import { clearMatrixCenter, zeroFillFinders } from "./bitMatrix.js";
 
 export async function getPDF(text: string, inOptions: ImageOptions) {
@@ -23,18 +22,12 @@ export async function getPDF(text: string, inOptions: ImageOptions) {
 }
 
 function colorToRGB(color: string | number): [number, number, number] {
-    if (typeof color === "string") {
-        const [red, green, blue] = colorString.get.rgb(color);
-        return [red / 255, green / 255, blue / 255];
-    }
-    return [((color >>> 24) % 256) / 255, ((color >>> 16) % 256) / 255, ((color >>> 8) % 256) / 255];
+    const { r, g, b } = parseColor(color);
+    return [r / 255, g / 255, b / 255];
 }
 
 function getOpacity(color: string | number): number {
-    if (typeof color === "string") {
-        return colorString.get.rgb(color)[3];
-    }
-    return (color % 256) / 255;
+    return parseColor(color).a;
 }
 
 async function PDF({

--- a/src/png.ts
+++ b/src/png.ts
@@ -76,5 +76,7 @@ export async function generateImage({
     const { data } = await qrImage
         .png({ palette: !logo }) // no logo results in much less colors
         .toBuffer({ resolveWithObject: true });
-    return new Uint8ClampedArray(data.buffer);
+    // `data` is a view into a possibly larger allocation, so bound the copy to the view itself
+    // rather than handing back whatever else shares that ArrayBuffer.
+    return new Uint8ClampedArray(data.buffer, data.byteOffset, data.byteLength);
 }

--- a/src/tests/_common.ts
+++ b/src/tests/_common.ts
@@ -15,6 +15,14 @@ const __dirname = dirname(__filename)
 export const goldenDir = `${__dirname}/../../test_data/golden`;
 export const generatedImageDir = `${__dirname}/../../test_data/generated`;
 
+/**
+ * A Buffer is a view into a possibly larger ArrayBuffer, so reading `.buffer` off one exposes
+ * whatever else happens to live in that allocation. Slice to the view's own bounds instead.
+ */
+export const toArrayBuffer = (
+    {buffer, byteOffset, byteLength}: {buffer: ArrayBufferLike; byteOffset: number; byteLength: number},
+): ArrayBuffer => buffer.slice(byteOffset, byteOffset + byteLength) as ArrayBuffer;
+
 export const assertEqual = async (t: ExecutionContext<unknown>, filename: string) => {
     if (filename.endsWith(".png")) {
         const lsRes = await looksSame(

--- a/src/tests/browser.test.ts
+++ b/src/tests/browser.test.ts
@@ -4,7 +4,7 @@ import { writeFile } from "node:fs/promises";
 import { ImageType } from '../typing/types.js';
 import { QRImageOptions } from '../qr.js';
 import { JSDOM } from 'jsdom';
-import { assertEqual, generatedImageDir, goldenDir } from "./_common.js";
+import { assertEqual, generatedImageDir, goldenDir, toArrayBuffer } from "./_common.js";
 import { Path2D } from "canvas";
 
 let functions: Record<ImageType, (text: string, options: QRImageOptions) => Promise<ArrayBuffer>>;
@@ -84,13 +84,13 @@ const defaultParams = {
         name: "PNG with logo (PNG)",
         type: "png",
         filename: "qr_with_logo.png",
-        params: { logo: readFileSync(`${goldenDir}/logo.png`).buffer },
+        params: { logo: toArrayBuffer(readFileSync(`${goldenDir}/logo.png`)) },
     },
     {
         name: "PNG with logo (JPG)",
         type: "png",
         filename: "qr_with_logo_jpg.png",
-        params: { logo: readFileSync(`${goldenDir}/logo.jpg`).buffer },
+        params: { logo: toArrayBuffer(readFileSync(`${goldenDir}/logo.jpg`)) },
     },
     {
         name: "PNG with colors (rgba)",
@@ -153,7 +153,7 @@ const defaultParams = {
         type: "svg",
         filename: "qr_with_logo_as_arraybuffer.svg",
         params: {
-            logo: readFileSync(`${goldenDir}/logo.png`).buffer,
+            logo: toArrayBuffer(readFileSync(`${goldenDir}/logo.png`)),
         },
     },
     {
@@ -161,7 +161,7 @@ const defaultParams = {
         type: "svg",
         filename: "qr_with_logo_as_arraybuffer_jpg.svg",
         params: {
-            logo: readFileSync(`${goldenDir}/logo.jpg`).buffer,
+            logo: toArrayBuffer(readFileSync(`${goldenDir}/logo.jpg`)),
         },
     },
     {
@@ -188,7 +188,7 @@ const defaultParams = {
         type: "pdf",
         filename: "qr_logo_arraybuffer.pdf",
         params: {
-            logo: new window.Uint8Array(readFileSync(`${goldenDir}/logo.png`).buffer),
+            logo: new window.Uint8Array(toArrayBuffer(readFileSync(`${goldenDir}/logo.png`))),
         },
     },
     {
@@ -196,7 +196,7 @@ const defaultParams = {
         type: "pdf",
         filename: "qr_logo_arraybuffer.pdf",
         params: {
-            logo: new window.Uint8Array(readFileSync(`${goldenDir}/logo.jpg`).buffer),
+            logo: new window.Uint8Array(toArrayBuffer(readFileSync(`${goldenDir}/logo.jpg`))),
         },
     },
 ] as unknown as TestParams[]) .forEach((testData) => {

--- a/src/tests/color.test.ts
+++ b/src/tests/color.test.ts
@@ -1,0 +1,40 @@
+import test from "ava";
+
+import { colorToHex } from "../utils.js";
+import { getSVG } from "../svg.js";
+import { getPDF } from "../pdf.js";
+
+const decoder = new TextDecoder();
+
+const finderFill = (params: Parameters<typeof getSVG>[1]) => {
+    const svg = decoder.decode(getSVG("https://example.com", params));
+    const match = svg.match(/fill-rule="evenodd" fill="([^"]*)"/);
+    if (!match) throw new Error("no finder path in SVG");
+    return match[1];
+};
+
+test("colorToHex rejects an unparseable color string", (t) => {
+    t.throws(() => colorToHex("ff0000"), { message: /Invalid color/ });
+});
+
+test("colorToHex keeps six digits for a fully opaque numeric color", (t) => {
+    t.is(colorToHex(0xff0000ff), "#ff0000");
+});
+
+test("colorToHex appends the alpha byte of a translucent numeric color", (t) => {
+    t.is(colorToHex(0xff000080), "#ff000080");
+});
+
+test("an unparseable finderColor never renders as an invisible NaN fill", (t) => {
+    t.throws(() => finderFill({ finderColor: "hsl(0 100% 50%)" }), { message: /Invalid color/ });
+});
+
+test("a translucent numeric finderColor keeps its alpha in SVG", (t) => {
+    t.is(finderFill({ finderColor: 0xff000080 }), "#ff000080");
+});
+
+test("PDF reports an unparseable finderColor as an invalid color", async (t) => {
+    await t.throwsAsync(() => getPDF("https://example.com", { finderColor: "ff0000" }), {
+        message: /Invalid color/,
+    });
+});

--- a/src/tests/finder.test.ts
+++ b/src/tests/finder.test.ts
@@ -1,0 +1,37 @@
+import test from "ava";
+
+import { getFinderInnerSVGPath, getFinderOuterSVGPath } from "../utils.js";
+import type { BitMatrix } from "../typing/types.js";
+
+const matrix = Array.from({ length: 21 }, () => new Array(21).fill(0)) as BitMatrix;
+const SIZE = 9;
+const MARGIN = 9;
+
+// Callers reach these helpers with `borderRadius` unset (it has no default in ImageOptions).
+// A non-finite radius used to leak into the path arithmetic and produce "M 9 NaN v NaN ...",
+// which browsers discard entirely — the finders rendered empty.
+const omitted = undefined as unknown as number;
+
+test("outer finder path has no NaN coordinates when borderRadius is omitted", (t) => {
+    t.false(getFinderOuterSVGPath(matrix, SIZE, MARGIN, omitted, "rounded").includes("NaN"));
+});
+
+test("inner finder path has no NaN coordinates when borderRadius is omitted", (t) => {
+    t.false(getFinderInnerSVGPath(matrix, SIZE, MARGIN, omitted, "rounded").includes("NaN"));
+});
+
+test("omitting borderRadius draws the same finders as borderRadius 0", (t) => {
+    t.is(
+        getFinderOuterSVGPath(matrix, SIZE, MARGIN, omitted, "rounded"),
+        getFinderOuterSVGPath(matrix, SIZE, MARGIN, 0, "rounded")
+    );
+    t.is(
+        getFinderInnerSVGPath(matrix, SIZE, MARGIN, omitted, "rounded"),
+        getFinderInnerSVGPath(matrix, SIZE, MARGIN, 0, "rounded")
+    );
+});
+
+test("a NaN borderRadius does not poison the finder path", (t) => {
+    t.false(getFinderOuterSVGPath(matrix, SIZE, MARGIN, NaN, "rounded").includes("NaN"));
+    t.false(getFinderInnerSVGPath(matrix, SIZE, MARGIN, NaN, "rounded").includes("NaN"));
+});

--- a/src/tests/logo.test.ts
+++ b/src/tests/logo.test.ts
@@ -1,0 +1,59 @@
+import test from "ava";
+import { readFileSync } from "node:fs";
+
+import { getSVG } from "../svg.js";
+import type { ImageOptions } from "../typing/types.js";
+import { goldenDir, toArrayBuffer } from "./_common.js";
+
+const decoder = new TextDecoder();
+
+const logoFile = readFileSync(`${goldenDir}/logo_45deg.png`);
+const logoBytes = new Uint8Array(logoFile);
+
+const sameBytes = (actual: Uint8Array, expected: Uint8Array) => {
+    if (actual.byteLength !== expected.byteLength) return false;
+    for (let index = 0; index < actual.byteLength; index++) {
+        if (actual[index] !== expected[index]) return false;
+    }
+
+    return true;
+};
+
+// The runtime accepts a typed array as well as an ArrayBuffer, even though the declared
+// `logo` type only covers the latter.
+const embeddedLogo = (logo: ArrayBufferView | ArrayBufferLike) => {
+    const logoOption = logo as ImageOptions["logo"];
+    const svg = decoder.decode(getSVG("https://example.com", { logo: logoOption, logoWidth: 20, logoHeight: 20 }));
+    const match = svg.match(/base64,([^"]*)"/);
+    if (!match) throw new Error("no logo embedded in SVG");
+    return new Uint8Array(Buffer.from(match[1], "base64"));
+};
+
+// Mimic a Buffer sitting inside a larger shared allocation, as `readFileSync` may return.
+const viewIntoLargerAllocation = () => {
+    const backing = new Uint8Array(logoBytes.byteLength + 4096);
+    backing.set(logoBytes, 0);
+    backing.fill(0xff, logoBytes.byteLength);
+    return new Uint8Array(backing.buffer, 0, logoBytes.byteLength);
+};
+
+test("a logo passed as a Buffer is embedded byte for byte", (t) => {
+    t.true(sameBytes(embeddedLogo(logoFile), logoBytes));
+});
+
+test("a logo passed as an ArrayBuffer is embedded byte for byte", (t) => {
+    t.true(sameBytes(embeddedLogo(toArrayBuffer(logoFile)), logoBytes));
+});
+
+test("toArrayBuffer copies only the bytes the view owns", (t) => {
+    const view = viewIntoLargerAllocation();
+    t.is(toArrayBuffer(view).byteLength, logoBytes.byteLength);
+    t.true(sameBytes(new Uint8Array(toArrayBuffer(view)), logoBytes));
+});
+
+test("the whole backing allocation would be embedded without the slice", (t) => {
+    const view = viewIntoLargerAllocation();
+    // This is the shape of the bug: `.buffer` ignores the view's bounds.
+    t.is(embeddedLogo(view.buffer).byteLength, logoBytes.byteLength + 4096);
+    t.is(embeddedLogo(toArrayBuffer(view)).byteLength, logoBytes.byteLength);
+});

--- a/src/tests/test.ts
+++ b/src/tests/test.ts
@@ -5,7 +5,7 @@ import { getPNG } from "../png.js";
 import { getSVG } from "../svg.js";
 import { getPDF } from "../pdf.js";
 import type { ImageOptions } from "../typing/types.js";
-import { assertEqual, generatedImageDir, goldenDir } from "./_common.js";
+import { assertEqual, generatedImageDir, goldenDir, toArrayBuffer } from "./_common.js";
 import { readFileSync } from "node:fs";
 
 const text = "I \u2764\uFE0F QR code!";
@@ -17,8 +17,8 @@ const defaultParams = {
     parse_url: true,
 };
 
-const logoJPEG = readFileSync(`${goldenDir}/logo.jpg`).buffer;
-const turnedLogo = readFileSync(`${goldenDir}/logo_45deg.png`).buffer;
+const logoJPEG = toArrayBuffer(readFileSync(`${goldenDir}/logo.jpg`));
+const turnedLogo = toArrayBuffer(readFileSync(`${goldenDir}/logo_45deg.png`));
 
 const generatorByType = {
     pdf: getPDF,
@@ -121,7 +121,7 @@ interface TestParams {
         name: "PNG with logo (arraybuffer)",
         fn: getPNG,
         filename: "qr_with_logo.png",
-        params: { logo: (await readFile(`${goldenDir}/logo.png`)).buffer },
+        params: { logo: toArrayBuffer(await readFile(`${goldenDir}/logo.png`)) },
     },
     {
         name: "SVG",
@@ -190,7 +190,7 @@ interface TestParams {
         fn: getSVG,
         filename: "qr_with_logo_as_arraybuffer.svg",
         params: {
-            logo: (await readFile(`${goldenDir}/logo.png`)).buffer,
+            logo: toArrayBuffer(await readFile(`${goldenDir}/logo.png`)),
         },
     },
     {
@@ -231,7 +231,7 @@ interface TestParams {
         fn: getPDF,
         filename: "qr_logo_arraybuffer.pdf",
         params: {
-            logo: (await readFile(`${goldenDir}/logo.png`)).buffer,
+            logo: toArrayBuffer(await readFile(`${goldenDir}/logo.png`)),
         },
     },
     {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,11 +7,50 @@ export function getOptions(inOptions: ImageOptions): ResolvedImageOptions {
     return { ...defaults, ...inOptions } as ResolvedImageOptions;
 }
 
+export interface RGBA {
+    /** 0-255 */
+    r: number;
+    /** 0-255 */
+    g: number;
+    /** 0-255 */
+    b: number;
+    /** 0-1 */
+    a: number;
+}
+
+/**
+ * Single source of truth for colors: accepts a 0xRRGGBBAA number or any CSS color string.
+ * Unparseable strings throw instead of silently degrading to an invisible fill.
+ */
+export function parseColor(color: number | string): RGBA {
+    if (typeof color === "number") {
+        return {
+            r: (color >>> 24) & 0xff,
+            g: (color >>> 16) & 0xff,
+            b: (color >>> 8) & 0xff,
+            a: (color & 0xff) / 255,
+        };
+    }
+    const rgb = colorString.get.rgb(color);
+    if (!rgb) {
+        throw new Error(
+            `Invalid color: ${JSON.stringify(color)}. Expected a CSS color string or a 0xRRGGBBAA number.`
+        );
+    }
+    const [r, g, b, a] = rgb;
+    return { r, g, b, a };
+}
+
 export function colorToHex(color: number | string): string {
     if (typeof color === "string") {
-        return colorString.to.hex(colorString.get.rgb(color));
+        const { r, g, b, a } = parseColor(color);
+        return colorString.to.hex([r, g, b, a]);
     }
-    return `#${(color >>> 8).toString(16).padStart(6, "0")}`;
+    const rgb = `#${(color >>> 8).toString(16).padStart(6, "0")}`;
+    const alpha = color & 0xff;
+    // Keep the compact form when fully opaque; otherwise carry alpha through so that
+    // SVG/Canvas honour it the same way the PDF renderer already does.
+    return alpha === 0xff ? rgb : `${rgb}${alpha.toString(16).padStart(2, "0")}`;
 }
 
 const svgMove = (left: number, top: number) => ['M', left, top]
@@ -118,12 +157,15 @@ const FINDER_END = 7; // finderSize(8) - 1
 // Index 1 is always the center-facing corner (toward QR center).
 function getCornerRadii(shape: FinderShape, sideLength: number, borderRadius: number): [number, number, number, number] {
     const maxR = sideLength / 2;
+    // A non-finite radius would propagate NaN through every delta below and invalidate the
+    // whole path, making the finders disappear. Treat it as "no rounding".
+    const r = Number.isFinite(borderRadius) ? borderRadius : 0;
     switch (shape) {
         case 'square': return [0, 0, 0, 0];
-        case 'rounded': return [borderRadius, borderRadius, borderRadius, borderRadius];
+        case 'rounded': return [r, r, r, r];
         case 'circle': return [maxR, maxR, maxR, maxR];
         case 'drop': return [maxR, 0, maxR, maxR];
-        default: return [borderRadius, borderRadius, borderRadius, borderRadius];
+        default: return [r, r, r, r];
     }
 }
 
@@ -151,7 +193,7 @@ function drawFinderRect(
 
 export function getFinderOuterSVGPath(
     matrix: Matrix, size: number, margin: number,
-    borderRadius: number, shape: FinderShape
+    borderRadius: number = 0, shape: FinderShape = 'rounded'
 ): string {
     const matrixSize = matrix.length * size + margin * 2;
     const rectangles: (string | number)[] = [];
@@ -171,7 +213,7 @@ export function getFinderOuterSVGPath(
 
 export function getFinderInnerSVGPath(
     matrix: Matrix, size: number, margin: number,
-    borderRadius: number, shape: FinderShape
+    borderRadius: number = 0, shape: FinderShape = 'rounded'
 ): string {
     const matrixSize = matrix.length * size + margin * 2;
     const rectangles: (string | number)[] = [];


### PR DESCRIPTION
getFinderOuterSVGPath and getFinderInnerSVGPath declared borderRadius without a default, unlike getFindersSVGPath and getDotsSVGPath. With it omitted, getCornerRadii('rounded', ..., undefined) returned four undefineds and `sideLength - r3 - r0` evaluated to NaN, poisoning every coordinate in the path:

    getFinderOuterSVGPath(matrix, 9, 9, undefined, 'rounded')
      -> "M 9 NaN v NaN h NaN v NaN h NaN z ..."

Consumers discard an NaN path wholesale, so the finders rendered empty. c7961e4 papered over this with `borderRadius ?? 0` at all three renderer call sites; the helpers themselves stayed broken for any other caller and for NaN/null input. Fix it at the source and treat a non-finite radius as no rounding.

Two adjacent defects with the same empty-finder symptom, fixed alongside:

- An unparseable colour string rendered fill="#00NANNAN" (invisible in browsers) and threw "object null is not iterable" from the PDF writer. A shared parseColor() now reports the bad value instead.
- Numeric colours dropped their alpha byte in SVG/PNG while the PDF renderer honoured it, so 0xff000080 was opaque in one output and 50% in another. colorToHex carries alpha through, and pdf.ts's duplicated colorToRGB/getOpacity delegate to parseColor.

Fully-opaque numeric colours still emit six digits, so the goldens are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved color handling across SVG and PDF output, including transparency support.
  * Invalid color values now produce clear errors instead of incorrect or invisible rendering.
  * Fixed finder patterns generating invalid coordinates when border radius is omitted or not finite.
  * Finder patterns now use consistent default styling when optional settings are not provided.

* **Tests**
  * Added coverage for color conversion, transparency, validation, PDF output, and finder pattern rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->